### PR TITLE
Fix singularly valued merged datasets

### DIFF
--- a/optim_esm_tools/analyze/combine_variables.py
+++ b/optim_esm_tools/analyze/combine_variables.py
@@ -180,8 +180,10 @@ def add_table(res_f, tips, ax=None, fontsize=16, pass_color=(0.75, 1, 0.75)):
 def result_table(ds, formats=None):
     res = {
         field: summarize_stats(ds, field, path)
-        for field, path in zip(oet.utils.to_str_tuple(ds.attrs['variables']),
-                               oet.utils.to_str_tuple(ds.attrs['source_files']))
+        for field, path in zip(
+            oet.utils.to_str_tuple(ds.attrs['variables']),
+            oet.utils.to_str_tuple(ds.attrs['source_files']),
+        )
     }
     thrs = default_thresholds()
     thrs['p_bhi'] = 0.01

--- a/optim_esm_tools/analyze/combine_variables.py
+++ b/optim_esm_tools/analyze/combine_variables.py
@@ -53,7 +53,7 @@ class VariableMerger:
         try:
             new_ds = xr.Dataset(**new_ds)
         except TypeError as e:  # pragma: no cover
-            oet.get_logger.warning(f'Ran into {e} fallback method because of cftime')
+            oet.get_logger().warning(f'Ran into {e} fallback method because of cftime')
             # Stupid cftime can't compare it's own formats
             data_vars = new_ds.pop('data_vars')
             new_ds = xr.Dataset(**new_ds)
@@ -65,7 +65,7 @@ class VariableMerger:
 
     def make_fig(self, new_ds=None, fig_kw=None):
         new_ds = new_ds or self.squash_sources()
-        variables = list(new_ds.attrs['variables'])
+        variables = list(oet.utils.to_str_tuple(new_ds.attrs['variables']))
         mapping = {str(i): v for i, v in enumerate(variables)}
         keys = list(mapping.keys()) + ['t']
 
@@ -95,6 +95,8 @@ class VariableMerger:
         )
         res_f, tips = result_table(new_ds)
         add_table(res_f=res_f, tips=tips, ax=axes['t'])
+        axes['global_map'] = ax
+        return axes
 
     def process_masks(self) -> ty.Tuple[dict, xr.DataArray]:
         source_files = {}
@@ -178,9 +180,11 @@ def add_table(res_f, tips, ax=None, fontsize=16, pass_color=(0.75, 1, 0.75)):
 def result_table(ds, formats=None):
     res = {
         field: summarize_stats(ds, field, path)
-        for field, path in zip(ds.attrs['variables'], ds.attrs['source_files'])
+        for field, path in zip(oet.utils.to_str_tuple(ds.attrs['variables']),
+                               oet.utils.to_str_tuple(ds.attrs['source_files']))
     }
     thrs = default_thresholds()
+    thrs['p_bhi'] = 0.01
     is_tip = pd.DataFrame(
         {
             k: {
@@ -193,8 +197,8 @@ def result_table(ds, formats=None):
 
     formats = formats or dict(
         n_breaks='.0f',
-        p_symmetry='.3f',
-        p_dip='.3f',
+        p_symmetry='.2%',
+        p_dip='.1%',
         max_jump='.1f',
         n_std_global='.1f',
     )

--- a/optim_esm_tools/analyze/time_statistics.py
+++ b/optim_esm_tools/analyze/time_statistics.py
@@ -192,7 +192,7 @@ def calculate_skewtest(ds, field=None, nan_policy='omit'):
     return scipy.stats.skewtest(values, nan_policy=nan_policy).pvalue
 
 
-def calculate_symmetry_test(ds, field=None, nan_policy='omit'):
+def calculate_symmetry_test(ds, field=None, nan_policy='omit', test_statistic='MI', **kw):
     import rpy_symmetry as rsym
 
     values = get_values_from_data_set(ds, field, add='')
@@ -201,7 +201,7 @@ def calculate_symmetry_test(ds, field=None, nan_policy='omit'):
     else:  # pragma: no cover
         message = 'Not sure how to deal with nans other than omit'
         raise NotImplementedError(message)
-    return rsym.p_symmetry(values)
+    return rsym.p_symmetry(values, test_statistic=test_statistic, **kw)
 
 
 def _get_tip_criterion(short_description):

--- a/optim_esm_tools/analyze/time_statistics.py
+++ b/optim_esm_tools/analyze/time_statistics.py
@@ -192,7 +192,9 @@ def calculate_skewtest(ds, field=None, nan_policy='omit'):
     return scipy.stats.skewtest(values, nan_policy=nan_policy).pvalue
 
 
-def calculate_symmetry_test(ds, field=None, nan_policy='omit', test_statistic='MI', **kw):
+def calculate_symmetry_test(
+    ds, field=None, nan_policy='omit', test_statistic='MI', **kw
+):
     import rpy_symmetry as rsym
 
     values = get_values_from_data_set(ds, field, add='')


### PR DESCRIPTION
very small bugfix, but saving `a=['b']` in dataset attrs will be loaded as `a='b'`