### PR TITLE
Repeated testing for `rpy_symmetry` tests

### DIFF
--- a/optim_esm_tools/analyze/time_statistics.py
+++ b/optim_esm_tools/analyze/time_statistics.py
@@ -207,13 +207,36 @@ def calculate_skewtest(ds, field=None, nan_policy='omit'):
 
 
 def calculate_symmetry_test(
-    ds,
-    field=None,
-    nan_policy='omit',
-    test_statistic='MI',
-    repeat=10,
+    ds: xr.Dataset,
+    field: ty.Optional[str] = None,
+    nan_policy: str = 'omit',
+    test_statistic: str = 'MI',
+    n_repeat: int = int(oet.config.config['analyze']['n_repeat_sym_test']),
     **kw,
-):
+) -> np.float64:
+    """The function `calculate_symmetry_test` calculates the symmetry test
+    statistic for a given dataset and field using the R package `rpy_symmetry`.
+
+    :param ds: An xarray Dataset containing the data
+    :type ds: xr.Dataset
+    :param field: The `field` parameter is an optional string that specifies the field or variable from
+    the dataset (`ds`) that you want to calculate symmetry test for. If `field` is not provided, the
+    function will calculate the symmetry test for all variables in the dataset
+    :type field: ty.Optional[str]
+    :param nan_policy: The `nan_policy` parameter determines how to handle missing values (NaNs) in the
+    data. The default value is 'omit', which means that any NaN values will be excluded from the
+    calculation, defaults to omit
+    :type nan_policy: str (optional)
+    :param test_statistic: The `test_statistic` parameter is a string that specifies the test statistic
+    to be used in the symmetry test. It determines how the symmetry of the data will be measured,
+    defaults to MI
+    :type test_statistic: str (optional)
+    :param n_repeat: The parameter `n_repeat` specifies the number of times the symmetry test should be
+    repeated. The symmetry test in R does give non-deterministic results. As such repeat a test this
+    many times and take the average
+    :type n_repeat: int
+    :return: The function `calculate_symmetry_test` returns a `np.float64` value.
+    """
     import rpy_symmetry as rsym
 
     values = get_values_from_data_set(ds, field, add='')
@@ -225,7 +248,7 @@ def calculate_symmetry_test(
     return np.mean(
         [
             rsym.p_symmetry(values, test_statistic=test_statistic, **kw)
-            for _ in range(repeat)
+            for _ in range(n_repeat)
         ],
     )
 

--- a/optim_esm_tools/analyze/time_statistics.py
+++ b/optim_esm_tools/analyze/time_statistics.py
@@ -211,6 +211,7 @@ def calculate_symmetry_test(
     field=None,
     nan_policy='omit',
     test_statistic='MI',
+    repeat=10,
     **kw,
 ):
     import rpy_symmetry as rsym
@@ -221,7 +222,12 @@ def calculate_symmetry_test(
     else:  # pragma: no cover
         message = 'Not sure how to deal with nans other than omit'
         raise NotImplementedError(message)
-    return rsym.p_symmetry(values, test_statistic=test_statistic, **kw)
+    return np.mean(
+        [
+            rsym.p_symmetry(values, test_statistic=test_statistic, **kw)
+            for _ in range(repeat)
+        ],
+    )
 
 
 def _get_tip_criterion(short_description):

--- a/optim_esm_tools/optim_esm_conf.ini
+++ b/optim_esm_tools/optim_esm_conf.ini
@@ -36,6 +36,9 @@ rpt_jump = 1
 rpt_model = rbf
 rpt_method = Pelt
 
+# The symmetry in R does give non-deterministic results. As such repeat a test this many times and take the average
+n_repeat_sym_test = 10
+
 [CMIP_files]
 folder_fmt = activity_id institution_id source_id experiment_id variant_label domain variable_id grid_label version
 base_name = merged.nc


### PR DESCRIPTION
Statistical tests are non-deterministic, so to reduce noise, tests 10 times for a given test