### PR TITLE
Improve direct region finding

### DIFF
--- a/optim_esm_tools/region_finding/keep_all.py
+++ b/optim_esm_tools/region_finding/keep_all.py
@@ -1,32 +1,50 @@
-from ._base import RegionExtractor, _mask_cluster_type
+from ._base import RegionExtractor, _mask_cluster_type, apply_options
 import itertools
 import numpy as np
+import typing as ty
+import xarray as xr
+import optim_esm_tools as oet
 
 
 class MaskAll(RegionExtractor):
-    def get_masks(self) -> _mask_cluster_type:  # pragma: no cover
-        mask_2d = ~self.data_set[self.variable].isnull().all(dim='time')
-        mask_values = mask_2d.values
-        lats = self.data_set['lat'].values
-        lons = self.data_set['lon'].values
-        masks = []
-        coords = []
+    @apply_options
+    def get_masks(
+        self,
+        step_size: int = 5,
+        force_continuity: bool = True,
+    ) -> _mask_cluster_type:  # pragma: no cover
+        mask_2d: xr.DataArray = ~self.data_set[self.variable].isnull().all(dim='time')
+        mask_values: np.ndarray = mask_2d.values
+        lats: np.ndarray = self.data_set['lat'].values
+        lons: np.ndarray = self.data_set['lon'].values
+        masks: ty.List[np.ndarray] = []
+        coords: ty.List[np.ndarray] = []
 
-        for i, j in itertools.product(range(mask_2d.shape[0]), range(mask_2d.shape[1])):
-            if mask_values[i][j]:
-                coords.append(
-                    np.array(
-                        [
-                            [
-                                lats[i],
-                                lons[j],
-                            ],
-                        ],
-                    ),
-                )
-                this_mask = np.zeros_like(mask_values)
-                this_mask[i][j] = True
+        for i, j in itertools.product(
+            range(0, mask_2d.shape[0], step_size),
+            range(0, mask_2d.shape[1], step_size),
+        ):
+            this_mask = np.zeros_like(mask_values)
+            this_coords = []
+            for ii in range(i, i + step_size):
+                if ii >= len(lats):
+                    continue
+                for jj in range(j, j + step_size):
+                    if jj >= len(lons):
+                        continue
+                    if mask_values[ii][jj]:
+                        this_coords.append([lats[ii], lons[jj]])
+                        this_mask[ii][jj] = True
+            if this_mask.sum():
+                coords.append(np.array(this_coords))
                 masks.append(this_mask)
+        if force_continuity:
+            masks = oet.analyze.clustering._split_to_continous(masks=masks)
+            lat, lon = np.meshgrid(lats, lons)
+            coords = [
+                oet.analyze.clustering._find_lat_lon_values(m, lats=lat.T, lons=lon.T)
+                for m in masks
+            ]
         return masks, coords
 
     def filter_masks_and_clusters(

--- a/optim_esm_tools/region_finding/percentiles.py
+++ b/optim_esm_tools/region_finding/percentiles.py
@@ -227,7 +227,10 @@ class Percentiles(RegionExtractor):
         combined_score = np.ones_like(ds[labels[0]].values, dtype=np.float64)
 
         for label in labels:
-            combined_score *= tipping_criteria.rank2d(ds[label].values)
+            try:
+                combined_score *= tipping_criteria.rank2d(ds[label].values)
+            except ValueError:
+                raise ValueError(ds[label].values, label)
         return combined_score
 
     def _product_rank_past_threshold(


### PR DESCRIPTION
## Improve `MaskAll`
This PR improves the `MaskAll` region finding method by setting a `step_size` for the number of gridcells to be included.
Previously, `MaskAll` would iterate over _each_ individual gridcell. For an `n90` gaussian grid, this lead to a huge number of regions to evaluate. 

Now, `step_size` determines how many cells in lon/lat are included, leading to a quadratic decrease in the number of found regions. The default of 5 means that each "region" found by `MaskAll` is 5x5 gridcells (or less, in case a portion of the gridcells are filled with nan-values).

### Know issues/downsides:
- There are no checks for the remainder, e.g. if a `steps_size=200` is set on a `360x180` grid, the first region will be 200x180, and the second region `160x180`, leading to sometimes wildly different region-sizes.
- Nans are ignored, but if there is only one value in the region, it will still return that region (with essentially only one valid gridcell). In the case of `step_size=5`, we normally get 25 cells per region, however, a region may only have 1 (valid)cell when the remaining 24 cells are nan-valued.
