### PR TITLE
Skip check-builtin-literals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-    -   id: check-builtin-literals
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml


### PR DESCRIPTION
Stop using builtin-literals from pre-commit