### PR TITLE
Speedup `mask_xr_ds` by a factor of `2-4x` using `numba`  when `drop=True`

### DIFF
--- a/optim_esm_tools/analyze/xarray_tools.py
+++ b/optim_esm_tools/analyze/xarray_tools.py
@@ -104,12 +104,15 @@ def mask_xr_ds(
         masked_dims = config['analyze']['lon_lat_dim'].split(',')[::-1]
 
     ds_start = data_set.copy()
-
     drop_true_function: ty.Callable = (
         _drop_by_mask
-        if (drop_method == 'xarray' or config['analyze']['use_drop_nb'] != 'True')
+        if (
+            drop_method == 'xarray'
+            or (drop_method is None and config['analyze']['use_drop_nb'] != 'True')
+        )
         else _drop_by_mask_nb
     )
+
     func_by_drop = {
         True: drop_true_function,
         False: _mask_xr_ds,

--- a/optim_esm_tools/analyze/xarray_tools.py
+++ b/optim_esm_tools/analyze/xarray_tools.py
@@ -5,6 +5,7 @@ import numpy as np
 import xarray as xr
 import numba
 from optim_esm_tools.config import config
+from optim_esm_tools.utils import check_accepts
 
 
 def _native_date_fmt(time_array: np.ndarray, date: ty.Tuple[int, int, int]):
@@ -88,13 +89,14 @@ def _remove_any_none_times(da: xr.DataArray, time_dim: bool, drop: bool = True) 
     return data_var
 
 
+@check_accepts(accepts=dict(drop_method=('xarray', 'numba')))
 def mask_xr_ds(
     data_set: xr.Dataset,
     da_mask: xr.DataArray,
     masked_dims: ty.Optional[ty.Iterable[str]] = None,
     drop: bool = False,
     keep_keys: ty.Optional[ty.Iterable[str]] = None,
-    _use_method: ty.Optional[str] = None,
+    drop_method: ty.Optional[str] = None,
 ):
     # Modify the ds in place - make a copy!
     data_set = data_set.copy()
@@ -105,7 +107,7 @@ def mask_xr_ds(
 
     drop_true_function: ty.Callable = (
         _drop_by_mask
-        if (_use_method == 'xarray' or config['analyze']['use_drop_nb'] != 'True')
+        if (drop_method == 'xarray' or config['analyze']['use_drop_nb'] != 'True')
         else _drop_by_mask_nb
     )
     func_by_drop = {

--- a/optim_esm_tools/analyze/xarray_tools.py
+++ b/optim_esm_tools/analyze/xarray_tools.py
@@ -329,19 +329,11 @@ def _drop_by_mask_nb(
             or k not in keep_keys
         )  # and k not in no_drop
     ]
-    try:
-        data_set = data_set.drop_vars(
-            (set(dropped) | set(keep_keys)) - {*masked_dims, fall_back_key},
-        )
-    except TypeError as e:
-        message = dict()
-        for k in 'dropped keep_keys masked_dims fall_back_key'.split():
-            print(f'{k} {eval(k)}')
-            try:
-                set(k)
-            except TypeError:
-                print(k)
-        raise ValueError(message) from e
+
+    data_set = data_set.drop_vars(
+        (set(dropped) | set(keep_keys)) - {*masked_dims, fall_back_key},
+    )
+
     data_set = data_set.where(da_mask.compute(), drop=True)
 
     assert fall_back_key in data_set

--- a/optim_esm_tools/optim_esm_conf.ini
+++ b/optim_esm_tools/optim_esm_conf.ini
@@ -42,6 +42,9 @@ n_repeat_sym_test = 10
 # tropics_latitude
 tropics_latitude = 23.05
 
+# if set to True, then use a faster - experimental numba subroutine
+use_drop_nb=False
+
 [CMIP_files]
 folder_fmt = activity_id institution_id source_id experiment_id variant_label domain variable_id grid_label version
 base_name = merged.nc

--- a/test/test_xarray_tools.py
+++ b/test/test_xarray_tools.py
@@ -43,7 +43,7 @@ class TestDrop(unittest.TestCase):
     def test_drop_by_mask(self):
         ds = oet._test_utils.minimal_xr_ds(len_x=8, len_y=9, len_time=10)
         ds['var'].data = np.random.randint(1, 10, size=ds['var'].shape)
-        mask = ds['var'].isel(time=0).drop('time') > 5
+        mask = ds['var'].isel(time=0).drop_vars('time') > 5
         kw = dict(
             data_set=ds,
             da_mask=mask,

--- a/test/test_xarray_tools.py
+++ b/test/test_xarray_tools.py
@@ -51,13 +51,14 @@ class TestDrop(unittest.TestCase):
             drop=True,
             keep_keys=None,
         )
-        dropped_xr = oet.analyze.xarray_tools.mask_xr_ds(
-            **kw,
-            drop_method='xarray',
-        )
+        ds['cell_area'] = mask.astype(np.int64)
         dropped_nb = oet.analyze.xarray_tools.mask_xr_ds(
             **kw,
             drop_method='numba',
+        )
+        dropped_xr = oet.analyze.xarray_tools.mask_xr_ds(
+            **kw,
+            drop_method='xarray',
         )
         v_xr = dropped_xr['var'].values
         v_nb = dropped_nb['var'].values

--- a/test/test_xarray_tools.py
+++ b/test/test_xarray_tools.py
@@ -3,6 +3,7 @@ import contextlib
 import numpy as np
 
 import optim_esm_tools as oet
+import unittest
 
 
 def test_remove_nan():
@@ -36,3 +37,29 @@ def test_global_mask():
         mask.dims,
         rev_renamed_mask.dims,
     )
+
+
+class TestDrop(unittest.TestCase):
+    def test_drop_by_mask(self):
+        ds = oet._test_utils.minimal_xr_ds(len_x=8, len_y=9, len_time=10)
+        ds['var'].data = np.random.randint(1, 10, size=ds['var'].shape)
+        mask = ds['var'].isel(time=0).drop('time') > 5
+        kw = dict(
+            data_set=ds,
+            da_mask=mask,
+            masked_dims=list(mask.dims),
+            drop=True,
+            keep_keys=None,
+        )
+        dropped_xr = oet.analyze.xarray_tools.mask_xr_ds(
+            **kw,
+            _use_method='xarray',
+        )
+        dropped_nb = oet.analyze.xarray_tools.mask_xr_ds(
+            **kw,
+            _use_method='numba',
+        )
+        v_xr = dropped_xr['var'].values
+        v_nb = dropped_nb['var'].values
+        self.assertTrue(np.array_equal(v_xr[~np.isnan(v_xr)], v_nb[~np.isnan(v_nb)]))
+        self.assertTrue(np.array_equal(np.isnan(v_xr), np.isnan(v_nb)))

--- a/test/test_xarray_tools.py
+++ b/test/test_xarray_tools.py
@@ -53,13 +53,18 @@ class TestDrop(unittest.TestCase):
         )
         dropped_xr = oet.analyze.xarray_tools.mask_xr_ds(
             **kw,
-            _use_method='xarray',
+            drop_method='xarray',
         )
         dropped_nb = oet.analyze.xarray_tools.mask_xr_ds(
             **kw,
-            _use_method='numba',
+            drop_method='numba',
         )
         v_xr = dropped_xr['var'].values
         v_nb = dropped_nb['var'].values
         self.assertTrue(np.array_equal(v_xr[~np.isnan(v_xr)], v_nb[~np.isnan(v_nb)]))
         self.assertTrue(np.array_equal(np.isnan(v_xr), np.isnan(v_nb)))
+        with self.assertRaises(ValueError):
+            oet.analyze.xarray_tools.mask_xr_ds(
+                **kw,
+                drop_method='numpy_or_somthing',
+            )


### PR DESCRIPTION
## Speedup `mask_xr_ds` by a factor of `2-4x` using `numba`  when `drop=True`
In this PR, we massively speedup one of the most time-consuming operations in this module, `optim_esm_tools.analyze.mask_xr_ds(..., drop=True)`. In order to do this, we abandon native `xarray` `Dataset.where(mask, drop=True)` for large 2d/3d arrays in the dataset. 
The new function: `_drop_by_mask_nb` is similar to `_drop_by_mask`, but follows the following logic:

1. Use `DataArray.where(mask, drop=True)` for a specified `2d` field, `'cell_area'` by default. For one 2d array- the operation is not that slow, and it makes it much easier to map indexes from the old dataset to the new dataset. 
2. Use the indexes for the specified 2d field to make a map between old indexes and new indexes.
3. Use a numba routine for filling the new data in the masked region. If the data-format is 3d, calculate each time slice (assumed to be the first dimension) recursively (but in numba, so very fast).

This new method is less robust, as we make assumptions about the underlying structure of the dataset, but as all the data is in principle pre-processed using the same schema, it does yield a very significant speed increase for this heavy function.

In case the dataset does not follow the schema that follows from the pre-processing, the functionality defaults back to methods very similar to the old `_drop_by_mask`. It might even have a slightly less performing than `_drop_by_mask`.

The functionality is adjustable using either a keyword-argument in `mask_xr_ds`, or updating a field in the config.