### PR TITLE
Exit early from candidates without passing propperties

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 24.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/awebdeveloper/pre-commit-stylelint
@@ -32,7 +32,3 @@ repos:
     hooks:
     -   id: stylelint
         additional_dependencies: ['stylelint@13.2.1', 'stylelint-config-standard@20.0.0']
-# -   repo: https://github.com/PyCQA/docformatter
-#     rev: 'v1.7.5'
-#     hooks:
-#     -   id: docformatter


### PR DESCRIPTION
# Exit early if candidates do not pass.
## Intro
In this PR, we fix an issue relating to evaluating regions in the `analyze.merge_candidate_regions.Merger` and (especially) `analyze.merge_candidate_regions.MergerCached`. In these methods, a list of regions is evaluated if:
 1. The region passes a predefined criterion
 2. The region can be expanded by merging adjacent/overlapping other regions

To achieve this, we **first sort** all available regions based on if they pass the predefined criterion, and then the size of the region. Then we can iteratively start performing the second step (expanding the region). 

## Issue
One advised method (also see the example notebook) is to add a set of small regions that could overlap/be adjacent to a passing region to get a large region. However, to save computational expense, we often cache the results of these small regions as nan-values (such that they don't pass the predefined criterion). This is done in `MergerCached.set_all_caches_as_false`. The issue resides in these regions. Since while we indeed correctly sort the available regions and iteratively resolve them, we did not check if the remaining candidates have would pass the predefined criterion.

This resulted in the small regions also being evaluated (if they would be merge-able during step 2) without explicitly checking step 1.

## Solution
This PR adds a check that step 1 is performed _every time we consider a new candidate_ before we continue with step 2.

## Effect
This is particularly relevant when adding regions and using `MergerCached.set_all_caches_as_false`. For the `Merger`-class the effect is minimal (when adding small regions there is no method to tell the `Merger` method to consider the regions any differently from other regions).