### PR TITLE
Break merging early for `merge_datasets`

### DIFF
--- a/optim_esm_tools/analyze/merge_candidate_regions.py
+++ b/optim_esm_tools/analyze/merge_candidate_regions.py
@@ -212,6 +212,7 @@ class Merger:
             pbar.display()
             self.log.info(pbar)
             doc = self._group_to_first(candidates)
+
             if not self.pass_criteria(**doc['stats']):
                 self.log.info(
                     f'Discarding group {doc["merged"]} because {doc["stats"]} does not pass',
@@ -230,6 +231,10 @@ class Merger:
                 )
                 groups.append(doc)
             candidates = [c for i, c in enumerate(candidates) if i not in doc['merged']]
+
+            if doc.get('force_break', False):
+                self.log.warning('Breaking forcefully')
+                candidates = []
         pbar.n = pbar.total
         pbar.close()
         pbar.display()
@@ -268,7 +273,8 @@ class Merger:
             self.log.info(
                 f"Exhausted passing regions, so next candidates are ignored ({len(candidates)-1} remaining)",
             )
-            return dict(stats=first_doc, ds=candidates[0], merged=[0])
+            # We are going to pass one additional argument that allows us to break the overencompasing loop
+            return dict(stats=first_doc, ds=candidates[0], merged=[0], force_break=True)
         while something_merged:
             something_merged = False
             for i, ds_alt in global_masks.items():

--- a/optim_esm_tools/analyze/region_calculation.py
+++ b/optim_esm_tools/analyze/region_calculation.py
@@ -606,16 +606,20 @@ def find_max_in_equal_area(
                 continue
 
             da_sel = data.where(da_m)
-            max_in_sel = float(
-                da_sel.where(da_m).mean("lat lon".split()).max(),
+
+            max_in_sel = oet.analyze.tools._weighted_mean_2d_numba(
+                da_sel.where(da_m).values,
+                weights=area.values,
             )
             if prev_mask is None or target_area > area_m2:
                 return dict(
                     area_m2=area_m2,
                     max_in_sel=max_in_sel,
                 )
-            prev_in_sel = float(
-                da_sel.where(prev_mask).mean("lat lon".split()).max(),
+
+            prev_in_sel = oet.analyze.tools._weighted_mean_2d_numba(
+                da_sel.where(prev_mask).values,
+                weights=area.values,
             )
             prev_area = float(area.where(prev_mask).sum())
 


### PR DESCRIPTION
In merge_datasets, we kept evaluating groups of candidate regions even when they had been set to not pass previously