### PR TITLE
Gridpatcher for holes in interpolated grids

### DIFF
--- a/optim_esm_tools/analyze/__init__.py
+++ b/optim_esm_tools/analyze/__init__.py
@@ -11,3 +11,4 @@ from . import time_statistics
 from . import tools
 from . import xarray_tools
 from . import region_calculation
+from . import discontinuous_grid_patcher

--- a/optim_esm_tools/analyze/discontinuous_grid_patcher.py
+++ b/optim_esm_tools/analyze/discontinuous_grid_patcher.py
@@ -1,0 +1,219 @@
+import typing as ty
+
+import numpy as np
+import optim_esm_tools as oet
+import xarray as xr
+from statsmodels.stats.weightstats import DescrStatsW
+
+
+class DiscontinuousGridPatcher:
+    min_samples_for_issue: int = 75
+    max_lon_weighted_std: ty.Union[float, int] = 4  # degrees, longitude
+
+    def __init__(
+        self,
+        ds: xr.Dataset,
+        should_have_data_mask: xr.DataArray,
+        iter_time: bool = False,
+        build_cluster_kw: ty.Optional[dict] = None,
+        split_cluster_kw: ty.Optional[dict] = None,
+    ):
+        """Patch holes in regridded data to allow continuous region finding.
+
+        Args:
+            ds (xr.Dataset): dataset to patch
+            should_have_data_mask (xr.DataArray): a lat/lon mask of where there should be data
+            iter_time (bool, optional): Iteratate over the time field. Defaults to False.
+            build_cluster_kw (ty.Optional[dict], optional): Optional arguments passed to
+                optim_esm_tools.analyze.clustering.build_cluster_mask. Defaults to None.
+            split_cluster_kw (ty.Optional[dict], optional): Optional arguments passed to
+            optim_esm_tools.analyze.clustering._split_to_continuous. Defaults to None.
+        """
+        self.ds = ds.copy()
+        self.should_have_data_mask: xr.DataArray = should_have_data_mask
+        self.iter_time: bool = iter_time
+        self.build_cluster_kw: ty.Dict = build_cluster_kw or dict(
+            min_samples=4,
+            max_distance_km=120,
+        )
+        self.split_cluster_kw: ty.Dict = split_cluster_kw or dict(
+            add_diagonal=False,
+            add_double_lon=False,
+        )
+
+    def find_issues(self) -> ty.List[np.ndarray]:
+        """Find issues in the dataset, if any return a list of masks where
+        issues exist.
+
+        Returns:
+            ty.List[np.ndarray]: List of issues
+        """
+        year_0 = self.ds[self.ds.variable_id].isel(time=0)
+        res = oet.analyze.clustering.build_cluster_mask(
+            (self.should_have_data_mask & year_0.isnull()).values.astype(bool),
+            year_0.lat.values,
+            year_0.lon.values,
+            **self.build_cluster_kw,
+        )
+        _, lon = np.meshgrid(self.ds.lat.values, self.ds.lon.values)
+        cell_a = self.ds["cell_area"].values
+
+        continous_masks = oet.analyze.clustering._split_to_continuous(
+            res[0],
+            **self.split_cluster_kw,
+        )
+        large_enough_masks = [
+            r for r in continous_masks if r.sum() >= self.min_samples_for_issue
+        ]
+
+        located_enough_masks = [
+            m
+            for m in large_enough_masks
+            if DescrStatsW(lon.T[m], weights=cell_a[m], ddof=0).std
+            < self.max_lon_weighted_std
+        ]
+        if len(continous_masks):
+            oet.get_logger().info(
+                f"Started with {len(continous_masks)} of which {len(large_enough_masks)} are >= {self.min_samples_for_issue} cells large. "
+                f"Finally, {len(located_enough_masks)} are actually also located enough (std < {self.max_lon_weighted_std}).",
+            )
+        return located_enough_masks
+
+    @staticmethod
+    def find_adjacency(mask: np.ndarray):
+        """Get cells that are one around the mask."""
+        import scipy.ndimage as ndimage
+
+        blurred = (
+            ndimage.gaussian_filter(
+                (mask > 0).astype(np.float64),
+                sigma=(0, 1),
+                order=0,
+            )
+            > 0.2
+        ).astype(np.int16)
+
+        return (blurred - mask.astype(np.int16)).astype(np.bool_)
+
+    def execute_patches(self, issues: ty.List[np.ndarray]) -> None:
+        for issue in issues:
+            self.execute_patch(issue)
+
+    def patch_one_variable(
+        self,
+        variable: str,
+        issue: np.ndarray,
+        adjacency_mask: np.ndarray,
+        iter_time: ty.Optional[bool] = None,
+    ) -> None:
+        """Patch the data in the dataset stored under "variable".
+
+        There are only a limited number of datastructures supported, if the NotImplementedError is raised,
+        one should add the appropriate handling proceidure for the datastructure.
+
+        Args:
+            variable (str): the data-array in the dataset to fix
+            issue (np.ndarray): the 2d-boolean mask for the issue to fix
+            adjacency_mask (np.ndarray): the result of self.find_adjacency(issue)
+            iter_time (ty.Optional[bool], optional): Iteratate over the time field. Defaults to None.
+
+        Raises:
+            NotImplementedError: If the data structure is unrecognized
+        """
+        iter_time = iter_time if iter_time is not None else self.iter_time
+        da = self.ds[variable].copy()
+        del self.ds[variable]
+        idx_lon = np.argwhere(np.array(da.dims) == "lon").squeeze()
+        idx_lat = np.argwhere(np.array(da.dims) == "lat").squeeze()
+
+        if idx_lat == 0 and idx_lon == 1 and len(da.shape) == 2:
+            values = da.values
+            temp = values.copy()
+            temp[~adjacency_mask] = np.nan
+            patch_data = np.nanmean(temp, axis=idx_lon)
+            values[issue] = np.repeat(patch_data, values.shape[idx_lon]).reshape(
+                values.shape,
+            )[issue]
+
+            da.data = values
+        elif idx_lat == 1 and idx_lon == 2 and len(da.shape) == 3 and not iter_time:
+            values = da.values
+            temp = values.copy()
+            temp[:, ~adjacency_mask] = np.nan
+            patch_data = np.nanmean(temp, axis=idx_lon)
+            values[:, issue] = np.repeat(patch_data, values.shape[idx_lon]).reshape(
+                values.shape,
+            )[:, issue]
+
+            da.data = values
+        elif idx_lat == 1 and idx_lon == 2 and len(da.shape) == 3 and iter_time:
+            for t_idx in oet.utils.tqdm(list(range(len(self.ds["time"])))):
+                da_t = da.isel(time=t_idx)
+                values = da_t.values
+                temp = values.copy()
+                temp[~adjacency_mask] = np.nan
+                patch_data = np.nanmean(temp, axis=idx_lon - 1)
+                values[issue] = np.repeat(
+                    patch_data,
+                    values.shape[idx_lon - 1],
+                ).reshape(values.shape)[issue]
+
+                da.data[t_idx] = values
+
+        else:
+            raise NotImplementedError(
+                idx_lat == 1,
+                idx_lon == 2,
+                len(da.shape) == 3,
+                not iter_time,
+            )
+
+        self.ds[variable] = da
+
+    def execute_patch(self, issue: np.ndarray) -> None:
+        """For an issue, find the adjacency mask and then execute the patch for
+        each DataArray in the Dataset one by one.
+
+        Args:
+            issue (np.ndarray): 2d boolean array of the issue
+        """
+        adjacency_mask = self.find_adjacency(issue)
+        patch_variables = [
+            v
+            for v in list(self.ds)
+            if all(
+                dim in self.ds[v].dims
+                for dim in oet.config.config["analyze"]["lon_lat_dim"].split(",")
+            )
+        ]
+        for variable in patch_variables:
+            self.patch_one_variable(variable, issue, adjacency_mask)
+
+    def patch_all_issues(self) -> xr.Dataset:
+        """Find all issues in the Dataset. If there are any, then iterate over
+        the issues and patch them one by one. If there are no issues, just
+        return the dataset as it is.
+
+        Returns:
+            xr.Dataset: A copy of the dataset with patches included, or if there are no issues found, the
+            original dataset.
+        """
+        issues = self.find_issues()
+        oet.get_logger().warning(
+            f"Finding {len(issues)} issues. N={[s.sum() for s in issues]}.",
+        )
+        if len(issues):
+            self.ds = self.ds.copy()
+            for issue in oet.utils.tqdm(
+                issues,
+                desc="patching issues",
+                disable=len(issues) <= 1,
+            ):
+                self.execute_patch(issue)
+            buffer = xr.zeros_like(self.ds['cell_area']).astype(bool)
+            for issue_mask in issues:
+                buffer.data = buffer.data | issue_mask
+            self.ds['patched_data'] = buffer
+            self.ds['patched_data'].attrs.update(description=f'{self.__class__.__name__} added data for {len(issues)} in these lat/lon places.')
+        self.ds.attrs.update({"Grid filler": f"Fixed {len(issues)}"})
+        return self.ds

--- a/optim_esm_tools/analyze/discontinuous_grid_patcher.py
+++ b/optim_esm_tools/analyze/discontinuous_grid_patcher.py
@@ -215,7 +215,7 @@ class DiscontinuousGridPatcher:
                 buffer.data = buffer.data | issue_mask
             self.ds['patched_data'] = buffer
             self.ds['patched_data'].attrs.update(
-                description=f'{self.__class__.__name__} added data for {len(issues)} in these lat/lon places.'
+                description=f'{self.__class__.__name__} added data for {len(issues)} in these lat/lon places.',
             )
         self.ds.attrs.update({"Grid filler": f"Fixed {len(issues)}"})
         return self.ds

--- a/optim_esm_tools/analyze/discontinuous_grid_patcher.py
+++ b/optim_esm_tools/analyze/discontinuous_grid_patcher.py
@@ -214,6 +214,8 @@ class DiscontinuousGridPatcher:
             for issue_mask in issues:
                 buffer.data = buffer.data | issue_mask
             self.ds['patched_data'] = buffer
-            self.ds['patched_data'].attrs.update(description=f'{self.__class__.__name__} added data for {len(issues)} in these lat/lon places.')
+            self.ds['patched_data'].attrs.update(
+                description=f'{self.__class__.__name__} added data for {len(issues)} in these lat/lon places.'
+            )
         self.ds.attrs.update({"Grid filler": f"Fixed {len(issues)}"})
         return self.ds

--- a/test/test_discontinous.py
+++ b/test/test_discontinous.py
@@ -1,3 +1,5 @@
+"""This unittest was written with the help of ChatGPT"""
+
 import unittest
 import numpy as np
 import xarray as xr

--- a/test/test_discontinous.py
+++ b/test/test_discontinous.py
@@ -1,0 +1,60 @@
+import unittest
+import numpy as np
+import xarray as xr
+from optim_esm_tools.analyze.discontinuous_grid_patcher import DiscontinuousGridPatcher
+
+class TestDiscontinuousGridPatcher(unittest.TestCase):
+    def setUp(self):
+        """Set up a synthetic dataset with missing values to test the patching."""
+        time = np.arange(3)  # Multiple time steps
+        lat = np.linspace(-89.5, 89.5, 180)
+        lon = np.linspace(-179.5, 179.5, 360)
+        data = np.random.rand(len(time), len(lat), len(lon))
+        data[:, :, 50:52] = np.nan  # Introduce missing values at a specific longitude
+        
+        cell_area = np.ones((len(lat), len(lon)))  # Dummy cell area values
+        
+        self.ds = xr.Dataset(
+            {"variable": (['time', 'lat', 'lon'], data),
+             "cell_area": (['lat', 'lon'], cell_area)},
+            coords={"time": time, "lat": lat, "lon": lon},
+            attrs={"variable_id": "variable"}  # Set the variable_id attribute
+        )
+        self.should_have_data_mask = xr.DataArray(
+            np.ones((len(lat), len(lon)), dtype=bool),  # Expect data everywhere
+            coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]
+        )
+        self.patcher = DiscontinuousGridPatcher(self.ds, self.should_have_data_mask)
+
+    def test_find_issues(self):
+        """Test if the patcher correctly identifies the missing data as an issue."""
+        issues = self.patcher.find_issues()
+        self.assertTrue(len(issues) > 0, "No issues detected when they should be.")
+
+    def test_patch_all_issues(self):
+        """Test if the patching mechanism correctly fills in missing values."""
+        patched_ds = self.patcher.patch_all_issues()
+        self.assertFalse(np.isnan(patched_ds["variable"].values).any(), "Patching did not fill all missing values.")
+
+    def test_patch_all_issues_with_iter_time(self):
+        """Test patching when iter_time is enabled."""
+        patcher = DiscontinuousGridPatcher(self.ds, self.should_have_data_mask, iter_time=True)
+        patched_ds = patcher.patch_all_issues()
+        self.assertFalse(np.isnan(patched_ds["variable"].values).any(), "Patching with iter_time did not fill all missing values.")
+
+    def test_invalid_dataset_dimension(self):
+        """Test if an incorrect dataset dimensionality raises NotImplementedError when executing patch."""
+
+        alt_data = np.random.rand(3, 2, 4, 5)  # Incorrect dimensions
+        alt_ds = xr.Dataset(
+            {"variable": (['a', 'b', 'lat', 'lon'], alt_data)},
+            coords={"a": np.arange(3),"b": np.arange(2), "lat": np.arange(4), "lon": np.arange(5)}
+        )
+        alt_ds['variable'].data[:,:,:,2:5] = np.nan
+        patcher = DiscontinuousGridPatcher(alt_ds, xr.ones_like(alt_ds['variable'].isel(a=0)))
+        
+        with self.assertRaises(NotImplementedError):
+            patcher.execute_patch(np.ones((4, 5), dtype=bool))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_discontinous.py
+++ b/test/test_discontinous.py
@@ -46,7 +46,9 @@ class TestDiscontinuousGridPatcher(unittest.TestCase):
     def test_patch_all_issues_with_iter_time(self):
         """Test patching when iter_time is enabled."""
         patcher = DiscontinuousGridPatcher(
-            self.ds, self.should_have_data_mask, iter_time=True
+            self.ds,
+            self.should_have_data_mask,
+            iter_time=True,
         )
         patched_ds = patcher.patch_all_issues()
         self.assertFalse(
@@ -69,7 +71,8 @@ class TestDiscontinuousGridPatcher(unittest.TestCase):
         )
         alt_ds['variable'].data[:, :, :, 2:5] = np.nan
         patcher = DiscontinuousGridPatcher(
-            alt_ds, xr.ones_like(alt_ds['variable'].isel(a=0))
+            alt_ds,
+            xr.ones_like(alt_ds['variable'].isel(a=0)),
         )
 
         with self.assertRaises(NotImplementedError):

--- a/test/test_discontinous.py
+++ b/test/test_discontinous.py
@@ -3,6 +3,7 @@ import numpy as np
 import xarray as xr
 from optim_esm_tools.analyze.discontinuous_grid_patcher import DiscontinuousGridPatcher
 
+
 class TestDiscontinuousGridPatcher(unittest.TestCase):
     def setUp(self):
         """Set up a synthetic dataset with missing values to test the patching."""
@@ -11,18 +12,21 @@ class TestDiscontinuousGridPatcher(unittest.TestCase):
         lon = np.linspace(-179.5, 179.5, 360)
         data = np.random.rand(len(time), len(lat), len(lon))
         data[:, :, 50:52] = np.nan  # Introduce missing values at a specific longitude
-        
+
         cell_area = np.ones((len(lat), len(lon)))  # Dummy cell area values
-        
+
         self.ds = xr.Dataset(
-            {"variable": (['time', 'lat', 'lon'], data),
-             "cell_area": (['lat', 'lon'], cell_area)},
+            {
+                "variable": (['time', 'lat', 'lon'], data),
+                "cell_area": (['lat', 'lon'], cell_area),
+            },
             coords={"time": time, "lat": lat, "lon": lon},
-            attrs={"variable_id": "variable"}  # Set the variable_id attribute
+            attrs={"variable_id": "variable"},  # Set the variable_id attribute
         )
         self.should_have_data_mask = xr.DataArray(
             np.ones((len(lat), len(lon)), dtype=bool),  # Expect data everywhere
-            coords={"lat": lat, "lon": lon}, dims=["lat", "lon"]
+            coords={"lat": lat, "lon": lon},
+            dims=["lat", "lon"],
         )
         self.patcher = DiscontinuousGridPatcher(self.ds, self.should_have_data_mask)
 
@@ -34,13 +38,21 @@ class TestDiscontinuousGridPatcher(unittest.TestCase):
     def test_patch_all_issues(self):
         """Test if the patching mechanism correctly fills in missing values."""
         patched_ds = self.patcher.patch_all_issues()
-        self.assertFalse(np.isnan(patched_ds["variable"].values).any(), "Patching did not fill all missing values.")
+        self.assertFalse(
+            np.isnan(patched_ds["variable"].values).any(),
+            "Patching did not fill all missing values.",
+        )
 
     def test_patch_all_issues_with_iter_time(self):
         """Test patching when iter_time is enabled."""
-        patcher = DiscontinuousGridPatcher(self.ds, self.should_have_data_mask, iter_time=True)
+        patcher = DiscontinuousGridPatcher(
+            self.ds, self.should_have_data_mask, iter_time=True
+        )
         patched_ds = patcher.patch_all_issues()
-        self.assertFalse(np.isnan(patched_ds["variable"].values).any(), "Patching with iter_time did not fill all missing values.")
+        self.assertFalse(
+            np.isnan(patched_ds["variable"].values).any(),
+            "Patching with iter_time did not fill all missing values.",
+        )
 
     def test_invalid_dataset_dimension(self):
         """Test if an incorrect dataset dimensionality raises NotImplementedError when executing patch."""
@@ -48,13 +60,21 @@ class TestDiscontinuousGridPatcher(unittest.TestCase):
         alt_data = np.random.rand(3, 2, 4, 5)  # Incorrect dimensions
         alt_ds = xr.Dataset(
             {"variable": (['a', 'b', 'lat', 'lon'], alt_data)},
-            coords={"a": np.arange(3),"b": np.arange(2), "lat": np.arange(4), "lon": np.arange(5)}
+            coords={
+                "a": np.arange(3),
+                "b": np.arange(2),
+                "lat": np.arange(4),
+                "lon": np.arange(5),
+            },
         )
-        alt_ds['variable'].data[:,:,:,2:5] = np.nan
-        patcher = DiscontinuousGridPatcher(alt_ds, xr.ones_like(alt_ds['variable'].isel(a=0)))
-        
+        alt_ds['variable'].data[:, :, :, 2:5] = np.nan
+        patcher = DiscontinuousGridPatcher(
+            alt_ds, xr.ones_like(alt_ds['variable'].isel(a=0))
+        )
+
         with self.assertRaises(NotImplementedError):
             patcher.execute_patch(np.ones((4, 5), dtype=bool))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## DiscontinuousGridPatcher
This PR add the `DiscontinuousGridPatcher` which is used to patch holes in a grid. This can occur when the interpolation by CDO does not assign any values to a specific latitude. An example is the NEMO grid used by IPSL. This left artificial holes in the data.

This does create trouble when running the clustering tools (`optim_esm_tools.analyze.clustering`) because there, we rely on adjacency for the clustering.

### Method
The DiscontinuousGridPatcher fills the missing values by interpolating between the adjacent cells (at the same latitude). 

### Use case
Preferably, this is only used in the region finding methods (`optim_esm_tools.analyze.region_calculation`) and **not** in the `optim_esm_tools.analyze.region_calculation`. The former relies on continuous regions for the region identification. The latter does not have such a requirement, but adding artificial data there might lead to undesirable result.