### PR TITLE
Optimized version of `is_excluded`

### DIFF
--- a/optim_esm_tools/analyze/find_matches.py
+++ b/optim_esm_tools/analyze/find_matches.py
@@ -150,7 +150,7 @@ def is_excluded(path: str, exclude_too_short: bool = True) -> bool:
 
     for exl in exlusion_list:
         if exl:
-            directories = path.split(os.sep)[-len(exlusion_list[0].split()) :]
+            directories = path.split(os.sep)[-len(exl.split()) :]
             path_ends_with = os.path.join(*directories)
             break
     else:
@@ -160,6 +160,7 @@ def is_excluded(path: str, exclude_too_short: bool = True) -> bool:
     for excluded in exlusion_list:
         if not excluded:
             continue
+
         if any(d not in excluded for d in directories_to_match):
             continue
         folders = excluded.split()


### PR DESCRIPTION
In this function we add a bit of extra logic of `is_excluded` to prevent many `fn` matches of excluded datasets that clearly do not match. 

## The issue
In the old version of `is_excluded`, the `fnmatch` line took ~1 ms per excluded dataset. Normally this is not so much of an issue but when the exclusion list is enlarged to ~1000 entries, the function takes ~1 s to check one path.

## The fix
Instead of doing an `fnmatch` on each possible excluded dataset, we first perform a light weight compare, that is if all the string entries in excluded are actually in the path.

## The result
It's about 300x faster for data that is not excluded

![image](https://github.com/user-attachments/assets/0da196b0-b823-41f0-874d-46b3036266c8)

