### PR TITLE
Further sort candidate regions on lat lon in `Merger`

### DIFF
--- a/optim_esm_tools/analyze/merge_candidate_regions.py
+++ b/optim_esm_tools/analyze/merge_candidate_regions.py
@@ -199,10 +199,8 @@ class Merger:
             -int(x['passes'] * 2) * _max_number_of_cells
             # Then by cell size
             - int(x['cells'])
-            # than by median latitude
-            - np.median(x['candidate'].lat) / 3600
-            # than by median longitude
-            - np.median(x['candidate'].lon) / 360000,
+            # than by median latitude, than by median longitude
+            - _med_lat_lon_scaled(x['candidate']['global_mask'], (360, 36000)),
         )
 
         self.data_sets = [c['candidate'] for c in candidates_sorted]
@@ -462,3 +460,15 @@ class MergerCached(Merger):
         for mask in masks:
             key = self.hash_for_mask(mask)
             self._cache[key] = fill_doc
+
+
+def _med_lat_lon(mask: xr.DataArray) -> ty.Tuple[float, float]:
+    dim = mask.dims
+    lat, lon = np.meshgrid(mask.coords[dim[0]], mask.coords[dim[1]])
+    mask_vals = mask.values.T
+    return np.median(lat[mask_vals]), np.median(lon[mask_vals])
+
+
+def _med_lat_lon_scaled(mask: xr.DataArray, scales=(360, 36000)) -> float:
+    """Scale lat lon by a number and return a single sum, e.g. for sorting based on median lat lon of mask"""
+    return sum(x / s for x, s in zip(_med_lat_lon(mask), scales))

--- a/optim_esm_tools/analyze/merge_candidate_regions.py
+++ b/optim_esm_tools/analyze/merge_candidate_regions.py
@@ -194,8 +194,15 @@ class Merger:
 
         candidates_sorted = sorted(
             candidates_info,
-            key=lambda x: -int(x['passes'] * 2) * _max_number_of_cells
-            - int(x['cells']),
+            key=lambda x:
+            # Sort first by passing
+            -int(x['passes'] * 2) * _max_number_of_cells
+            # Then by cell size
+            - int(x['cells'])
+            # than by median latitude
+            - np.median(x['candidate'].lat) / 3600
+            # than by median longitude
+            - np.median(x['candidate'].lon) / 360000,
         )
 
         self.data_sets = [c['candidate'] for c in candidates_sorted]

--- a/optim_esm_tools/plotting/plot.py
+++ b/optim_esm_tools/plotting/plot.py
@@ -19,7 +19,8 @@ def setup_map(
     no_top_labels: bool = True,
     **projection_kwargs,
 ):
-    plt.gcf().add_subplot(*a,
+    plt.gcf().add_subplot(
+        *a,
         projection=get_cartopy_projection(projection, **projection_kwargs),
     )
     ax = plt.gca()

--- a/optim_esm_tools/plotting/plot.py
+++ b/optim_esm_tools/plotting/plot.py
@@ -18,7 +18,7 @@ def setup_map(
     gridline_kw: ty.Optional[dict] = None,
     no_top_labels: bool = True,
     **projection_kwargs,
-):
+) -> ty.Tuple[ty.Any, ty.Any]:
     plt.gcf().add_subplot(
         *a,
         projection=get_cartopy_projection(projection, **projection_kwargs),
@@ -39,6 +39,7 @@ def setup_map(
         gl = ax.gridlines(**gridline_kw)
         if no_top_labels:
             gl.top_labels = False
+    return ax, gl
 
 
 def _show(show):


### PR DESCRIPTION
## Change sorting of candidate regions in `Merger`
Small tweak to improve transparency. In this PR we slightly change the order of candidate region sorting in `Merger.set_passing_largest_data_sets_first`. This later affects the order in which regions are merged, after this PR, it's a bit easier to explain (that it's iteratively tried and goes from high lat to low lat, and from high lon to low lon. 

## Example
Old order
![mask_roi_old](https://github.com/user-attachments/assets/8c68fabf-5de2-4c28-9cfe-3c7b0a9d6d01)

New order
![mask_roi_new](https://github.com/user-attachments/assets/a0fe956a-8c1a-4452-84d4-d63e81f20ca7)
