### PR TITLE
Calculate frac for lowess based on non-nan values

### DIFF
--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -47,7 +47,7 @@ def rank2d(a):
 
 
 def smoother_lowess_year(a, n_year=40, **kw):
-    
+
     frac = n_year / np.sum(~np.isnan(a))
     if 'frac' in kw:
         raise ValueError

--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -50,9 +50,8 @@ def smoother_lowess_year(a, n_year=40, **kw):
     frac = n_year / np.sum(~np.isnan(a))
     if np.sum(np.isnan(a)):
         from optim_esm_tools import get_logger
-
         get_logger().warning(
-            f'One or more nans detected which might lead to unwanted effects'
+            'One or more nans detected which might lead to unwanted effects'
         )
     if 'frac' in kw:
         raise ValueError

--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -50,8 +50,9 @@ def smoother_lowess_year(a, n_year=40, **kw):
     frac = n_year / np.sum(~np.isnan(a))
     if np.sum(np.isnan(a)):
         from optim_esm_tools import get_logger
+
         get_logger().warning(
-            'One or more nans detected which might lead to unwanted effects'
+            'One or more nans detected which might lead to unwanted effects',
         )
     if 'frac' in kw:
         raise ValueError

--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -47,7 +47,8 @@ def rank2d(a):
 
 
 def smoother_lowess_year(a, n_year=40, **kw):
-    frac = n_year / len(a)
+    
+    frac = n_year / np.sum(~np.isnan(a))
     if 'frac' in kw:
         raise ValueError
     return partial(

--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -47,8 +47,10 @@ def rank2d(a):
 
 
 def smoother_lowess_year(a, n_year=40, **kw):
-
     frac = n_year / np.sum(~np.isnan(a))
+    if np.sum(np.isnan(a)):
+        from optim_esm_tools import get_logger
+        get_logger().warning(f'One or more nans detected which might lead to unwanted effects')
     if 'frac' in kw:
         raise ValueError
     return partial(

--- a/optim_esm_tools/analyze/tools.py
+++ b/optim_esm_tools/analyze/tools.py
@@ -50,7 +50,10 @@ def smoother_lowess_year(a, n_year=40, **kw):
     frac = n_year / np.sum(~np.isnan(a))
     if np.sum(np.isnan(a)):
         from optim_esm_tools import get_logger
-        get_logger().warning(f'One or more nans detected which might lead to unwanted effects')
+
+        get_logger().warning(
+            f'One or more nans detected which might lead to unwanted effects'
+        )
     if 'frac' in kw:
         raise ValueError
     return partial(


### PR DESCRIPTION
For the lowess filter, we use a fixed window, while lowess need a fraction of the data. 
We convert between the two using len(a), but this is not completely correct as there may be a number of nans in the values that we later remove.

